### PR TITLE
WIP: ファーストビュー画像の位置とサイズの調整を行った

### DIFF
--- a/180509/index.html
+++ b/180509/index.html
@@ -58,9 +58,9 @@
 
     <!--サイド調整-->
     <div class="container">
-
+      <div class="pt-5 mt-4"></div>
       <!--最初の画像-->
-    <img class="d-block rounded mx-auto d-block w-100  " src="image/slide_0.jpg" alt=width="200" height="299" border="0">
+    <img class="d-block rounded mx-auto d-block w-75 img-thumbnail" src="image/slide_0.jpg" alt="ファーストビュー画像" border="0">
  <br><br>
 
       <!--紹介-->


### PR DESCRIPTION
* アスペクト比がおかしくなっていたのでheight/widthの指定を外し、横幅75%に（w-75）修正
* 画像の上部がナビゲーションに隠れてしまっていたので、固定margin/paddingを付けて一番上まで見えるように修正

以下、参考スクショ

## before

![screenshot 2018-05-16 18 10 10](https://user-images.githubusercontent.com/818249/40107870-67ad59ba-5934-11e8-92c1-bbbe7ac5e475.png)

## after

![screenshot 2018-05-16 18 06 06](https://user-images.githubusercontent.com/818249/40107705-f2d920ba-5933-11e8-83d0-ede34862e063.png)
